### PR TITLE
__has_includeを#ifdefに変えた

### DIFF
--- a/src/Udon/Actuator/MotorDriver.hpp
+++ b/src/Udon/Actuator/MotorDriver.hpp
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#if __has_include(<Arduino.h>)
+#ifdef ARDUINO
 
 #    include <Arduino.h>
 #    include <Udon/Algorithm/MovingAverage.hpp>

--- a/src/Udon/Algorithm/LoopCycleController.hpp
+++ b/src/Udon/Algorithm/LoopCycleController.hpp
@@ -8,7 +8,7 @@
 //    Licensed under the MIT License.
 //
 //-------------------------------------------------------------------
-// 
+//
 //    ループ周期を一定にする
 //
 //-------------------------------------------------------------------
@@ -16,7 +16,7 @@
 #ifndef DEF_LoopCycleController_H
 #define DEF_LoopCycleController_H
 
-#if __has_include(<Arduino.h>)
+#ifdef ARDUINO
 
 #    include <Arduino.h>
 
@@ -100,5 +100,5 @@ namespace Udon
 
 }    // namespace Udon
 
-#endif
-#endif
+#endif    // ARDUINO
+#endif    // DEF_LoopCycleController_H

--- a/src/Udon/Display/SegmentsLed.hpp
+++ b/src/Udon/Display/SegmentsLed.hpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <stdint.h>
 
-#if __has_include(<Arduino.h>)
+#ifdef ARDUINO
 
 #    include <Arduino.h>
 
@@ -107,4 +107,4 @@ namespace Udon
 
 }    // namespace Udon
 
-#endif
+#endif 

--- a/src/Udon/Sensor/DipSwitch.hpp
+++ b/src/Udon/Sensor/DipSwitch.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <stdint.h>
 
-#if __has_include(<Arduino.h>)
+#ifdef ARDUINO
 
 #    include <Arduino.h>
 
@@ -58,4 +58,4 @@ namespace Udon
 
 }    // namespace Udon
 
-#endif    // __has_include(<Arduino.h>)
+#endif     


### PR DESCRIPTION
```cpp
#if __has_include(<Arduino.h>)
```
↓
```cpp
#ifdef ARDUINO
#include <Arduino.h>
```

- `UdonLibrary` をincludeする前に `Arduino.h` がincludeされてている必要があります( `Arduino.h` 内で`ARDUINO`が定義されるため)