### PR TITLE
Optional改良

### DIFF
--- a/src/Udon/Algorithm/StringToNumberParser.hpp
+++ b/src/Udon/Algorithm/StringToNumberParser.hpp
@@ -77,7 +77,16 @@ namespace Udon
         {
             char* endPtr = nullptr;
 
-            const auto result = strtof(begin, &endPtr);
+#if defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA) || defined(ARDUINO_AVR_MEGA2560)
+
+            // nano 系統にstrtofが定義されていなかった
+            const float result = static_cast<float>(strtod(begin, &endPtr));
+
+#else
+
+            const float result = strtof(begin, &endPtr);
+
+#endif
 
             if (endPtr == end)
             {

--- a/src/Udon/Algorithm/StringToNumberParser.hpp
+++ b/src/Udon/Algorithm/StringToNumberParser.hpp
@@ -75,7 +75,18 @@ namespace Udon
         template <>
         inline Udon::Optional<float> Parse<float>(const char* const begin, const char* const end, const int /*radix*/)
         {
-            return Parse<double>(begin, end, 10);
+            char* endPtr = nullptr;
+
+            const auto result = strtof(begin, &endPtr);
+
+            if (endPtr == end)
+            {
+                return result;
+            }
+            else
+            {
+                return Udon::nullopt;
+            }
         }
 
     }    // namespace StringToNumberParser

--- a/src/Udon/Types/Optional.hpp
+++ b/src/Udon/Types/Optional.hpp
@@ -551,7 +551,7 @@ namespace Udon
         template <typename U>
         void ConstructValue(U&& value) noexcept(std::is_nothrow_constructible<ValueType, U>::value)
         {
-            new (&mStorage.value) ValueType(static_cast<ValueType>(std::forward<U>(value)));
+            new (&mStorage.value) ValueType(std::forward<U>(value));
         }
 
         template <typename U>

--- a/test/UnitTest/CMakeLists.txt
+++ b/test/UnitTest/CMakeLists.txt
@@ -10,6 +10,7 @@ project(UnitTest)
 if (MSVC)
     add_compile_options(/std:c++14)   # Enable C++14
     add_compile_options(/permissive-) # Enable conformance mode
+    add_compile_options(/wd4819)      # エンコーディングの違いによるエラーを無効化 ()
 endif()
 
 


### PR DESCRIPTION
Optional が保持する型の暗黙変換を削除した

```cpp
// 変更前は警告なし
Udon::Optional<int> i = 100.0;

// 変更後は警告あり (double から int への変換による
Udon::Optional<int> i = 100.0;
```