### PR TITLE
Add optional transform

### DIFF
--- a/src/Udon/Types/Optional.hpp
+++ b/src/Udon/Types/Optional.hpp
@@ -462,17 +462,6 @@ namespace Udon
 
 
         /**
-         * @brief 値を変換
-         */
-        template <typename Visitor>
-        constexpr auto transform(Visitor&& visitor) const&& -> Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(const ValueType)>::type>>
-        {
-            return *this ? Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(const ValueType)>::type>>{ visitor(std::move(**this)) }
-                         : nullopt;
-        }
-
-
-        /**
          * @brief 他のOptionalと値を交換する
          */
         void swap(Optional& other) noexcept(/* std::is_nothrow_swappable<ValueType>::value and*/ std::is_nothrow_move_assignable<ValueType>::value)

--- a/src/Udon/Types/Optional.hpp
+++ b/src/Udon/Types/Optional.hpp
@@ -12,7 +12,7 @@
 #include <new>
 
 #if __has_include(<new.h>)
-#   include <new.h>
+#    include <new.h>
 #endif
 
 namespace Udon
@@ -67,7 +67,8 @@ namespace Udon
 
         static_assert(not std::is_array<T>::value, "T must not be an array");
 
-        template <typename> friend class Optional;
+        template <typename>
+        friend class Optional;
 
     public:
         using ValueType = T;
@@ -121,7 +122,7 @@ namespace Udon
                 ConstructValue(other.mStorage.value);
             }
         }
-    
+
 
         /**
          * @brief ムーブコンストラクタ
@@ -428,6 +429,50 @@ namespace Udon
 
 
         /**
+         * @brief 値を変換
+         */
+        template <typename Visitor>
+        constexpr auto transform(Visitor&& visitor) & -> Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(ValueType&)>::type>>
+        {
+            return *this ? Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(ValueType&)>::type>>{ visitor(**this) }
+                         : nullopt;
+        }
+
+
+        /**
+         * @brief 値を変換
+         */
+        template <typename Visitor>
+        constexpr auto transform(Visitor&& visitor) const& -> Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(const ValueType&)>::type>>
+        {
+            return *this ? Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(const ValueType&)>::type>>{ visitor(**this) }
+                         : nullopt;
+        }
+
+
+        /**
+         * @brief 値を変換
+         */
+        template <typename Visitor>
+        constexpr auto transform(Visitor&& visitor) && -> Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(ValueType)>::type>>
+        {
+            return *this ? Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(ValueType)>::type>>{ visitor(std::move(**this)) }
+                         : nullopt;
+        }
+
+
+        /**
+         * @brief 値を変換
+         */
+        template <typename Visitor>
+        constexpr auto transform(Visitor&& visitor) const&& -> Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(const ValueType)>::type>>
+        {
+            return *this ? Optional<Traits::RemoveCVRefT<typename std::result_of<Visitor(const ValueType)>::type>>{ visitor(std::move(**this)) }
+                         : nullopt;
+        }
+
+
+        /**
          * @brief 他のOptionalと値を交換する
          */
         void swap(Optional& other) noexcept(/* std::is_nothrow_swappable<ValueType>::value and*/ std::is_nothrow_move_assignable<ValueType>::value)
@@ -447,7 +492,7 @@ namespace Udon
                 reset();
             }
         }
-        
+
 
         /**
          * @brief 無効状態にする (トリビアルな型)

--- a/test/UnitTest/Types/Optional.cpp
+++ b/test/UnitTest/Types/Optional.cpp
@@ -469,6 +469,23 @@ TEST(Optional, ValueOr)
     }
 }
 
+TEST(Optional, Transform)
+{
+    {
+        Udon::Optional<int> a = 1;
+        auto b = a.transform([](int v)
+                             { return v + 1; });
+        EXPECT_EQ(*b, 2);
+    }
+
+    {
+        Udon::Optional<int> a;
+        auto b = a.transform([](int v)
+                             { return v + 1; });
+        EXPECT_FALSE(b);
+    }
+}
+
 TEST(Optional, Reset)
 {
     Udon::Optional<Copyable> a{ 100 };


### PR DESCRIPTION
`Optional<T>::transform()` を実装し、Optionalの型変換を容易に行えるようにした。

### 追加前

```cpp
class Encoder
{
public:
    // ... 略

    Udon::Optional<int> getCount() const
    {
        if (const auto message = reader.getMessage())
        {
            return message->count;
        }
        else
        {
            return Udon::nullopt;
        }
    }
};
```

### 追加後

```cpp
class Encoder
{
public:
    // ... 略

    Udon::Optional<int> getCount() const
    {
        return reader
            .getMessage()
            .transform([](const Udon::Message::Encoder& message)
                       { return message.count; });
    }
};
```