### PR TITLE
Udon::Direction 導入

### DIFF
--- a/src/Udon/Com/Driver/Encoder.hpp
+++ b/src/Udon/Com/Driver/Encoder.hpp
@@ -12,9 +12,9 @@
 #include <Udon/Algorithm/DeltaTime.hpp>
 #include <Udon/Com/Message/Encoder.hpp>
 #include <Udon/Traits/HasMemberFunction.hpp>
-
 #include <Udon/Traits/ReaderWriterTraits.hpp>
 #include <Udon/Utility/Printf.hpp>
+#include <Udon/Types/Direction.hpp>
 
 namespace Udon
 {
@@ -32,7 +32,7 @@ namespace Udon
 
         Udon::DeltaTime deltaTime;
 
-        bool direction;
+        Udon::Direction direction;
 
         int32_t count{};
         int32_t deltaCount{};
@@ -43,7 +43,7 @@ namespace Udon
         /// @brief コンストラクタ
         /// @param reader 受信クラスオブジェクト
         /// @param direction 回転方向
-        EncoderBy(ReaderType&& reader, bool direction)
+        EncoderBy(ReaderType&& reader, Udon::Direction direction = Udon::Direction::Forward)
             : reader(std::move(reader))
             , deltaTime()
             , direction(direction)
@@ -59,7 +59,7 @@ namespace Udon
 
             if (const auto countOpt = reader.getMessage())
             {
-                count = countOpt->count * (direction ? 1 : -1);
+                count = countOpt->count * Udon::DirectionToSign(direction);
             }
 
             const auto curr = getCount();

--- a/src/Udon/Com/Driver/Motor.hpp
+++ b/src/Udon/Com/Driver/Motor.hpp
@@ -13,6 +13,7 @@
 #include <Udon/Traits/HasMemberFunction.hpp>
 #include <Udon/Utility/Show.hpp>
 #include <Udon/Traits/ReaderWriterTraits.hpp>
+#include <Udon/Types/Direction.hpp>
 
 namespace Udon
 {
@@ -28,14 +29,14 @@ namespace Udon
 
         int16_t power;    // 出力値 -255 ~ 255
 
-        bool direction;    // 回転方向 true: forward, false: backward
+        Udon::Direction direction;    // 回転方向
 
     public:
 
         /// @brief コンストラクタ
         /// @param writer 送信クラスオブジェクト
         /// @param direction 回転方向
-        MotorBy(WriterType&& writer, bool direction)
+        MotorBy(WriterType&& writer, Udon::Direction direction = Udon::Direction::Forward)
             : writer(std::move(writer))
             , power()
             , direction(direction)
@@ -47,7 +48,7 @@ namespace Udon
         void move(int16_t p)
         {
             power = Constrain(p, (int16_t)-255, (int16_t)255);
-            writer.setMessage({ static_cast<int16_t>(power * (direction ? 1 : -1)) });
+            writer.setMessage({ static_cast<int16_t>(power * Udon::DirectionToSign(direction)) });
             Udon::Traits::MaybeInvokeUpdate(writer);
         }
 

--- a/src/Udon/Driver/EncoderPico.hpp
+++ b/src/Udon/Driver/EncoderPico.hpp
@@ -12,6 +12,7 @@
 #    include "Pio/QuadratureEncoder.pio.hpp"
 
 #    include <Udon/Algorithm/ScopedInterruptLocker.hpp>
+#    include <Udon/Types/Direction.hpp>
 
 namespace Udon
 {
@@ -22,15 +23,19 @@ namespace Udon
         uint8_t pinA;
         uint8_t pinB;
 
+        Udon::Direction direction;
+
         Pio::StateMachine stateMachine;    // PIO使用時
 
     public:
         /// @brief コンストラクタ
         /// @param pinA エンコーダーのA相ピン
         /// @param pinB エンコーダーのB相ピン
-        EncoderPico(uint8_t pinA, uint8_t pinB)
+        /// @param direction 回転方向
+        EncoderPico(uint8_t pinA, uint8_t pinB, Udon::Direction direction = Udon::Direction::Forward)
             : pinA(pinA)
             , pinB(pinB)
+            , direction(direction)
             , stateMachine()
         {
         }
@@ -68,7 +73,7 @@ namespace Udon
         /// @return エンコーダーの値
         int32_t read() const
         {
-            return Pio::Encoder::quadrature_encoder_get_count(stateMachine.pio, stateMachine.index);
+            return Pio::Encoder::quadrature_encoder_get_count(stateMachine.pio, stateMachine.index) * Udon::DirectionToSign(direction);
         }
 
         /// @brief エンコーダーの値を表示する

--- a/src/Udon/Driver/Motor.hpp
+++ b/src/Udon/Driver/Motor.hpp
@@ -10,6 +10,7 @@
 
 #    include <Arduino.h>
 #    include <Udon/Algorithm/MovingAverage.hpp>
+#    include <Udon/Types/Direction.hpp>
 
 namespace Udon
 {
@@ -22,17 +23,20 @@ namespace Udon
         const uint8_t pinA;
         const uint8_t pinP;
 
-        Udon::MovingAverage<SmoothLevel> movingAverage;
+        Udon::Direction direction;
+
+        Udon::MovingAverage<SmoothLevel> ma;
 
     public:
 
         /// @brief コンストラクタ
         /// @param pinA 方向ピン
         /// @param pinP PWM ピン
-        SmoothlyMotor2(const uint8_t pinA, const uint8_t pinP)
+        SmoothlyMotor2(const uint8_t pinA, const uint8_t pinP, Udon::Direction direction = Udon::Direction::Forward)
             : pinA(pinA)
             , pinP(pinP)
-            , movingAverage{}
+            , direction(direction)
+            , ma{}
         {
         }
 
@@ -46,7 +50,7 @@ namespace Udon
         /// @param power パワー (-250 ～ 250)
         void move(const int16_t power)
         {
-            const int16_t p = movingAverage(constrain(power, -250, 250));
+            const int16_t p = ma(constrain(power, -250, 250)) * Udon::DirectionToSign(direction);
             digitalWrite(pinA, p >= 0 ? HIGH : LOW);
             analogWrite(pinP, abs(p));
         }
@@ -60,7 +64,7 @@ namespace Udon
         /// @brief パワーをシリアル出力
         void show() const
         {
-            Serial.print(movingAverage.getValue());
+            Serial.print(ma.getValue());
             Serial.print('\t');
         }
     };
@@ -74,7 +78,9 @@ namespace Udon
         const uint8_t pinB;
         const uint8_t pinP;
 
-        Udon::MovingAverage<SmoothLevel> movingAverage;
+        Udon::Direction direction;
+
+        Udon::MovingAverage<SmoothLevel> ma;
 
     public:
 
@@ -82,11 +88,13 @@ namespace Udon
         /// @param pinA 方向ピン
         /// @param pinB 方向ピン
         /// @param pinP PWM ピン
-        SmoothlyMotor3(const uint8_t pinA, const uint8_t pinB, const uint8_t pinP)
+        /// @param direction 回転方向
+        SmoothlyMotor3(const uint8_t pinA, const uint8_t pinB, const uint8_t pinP, Udon::Direction direction = Udon::Direction::Forward)
             : pinA(pinA)
             , pinB(pinB)
             , pinP(pinP)
-            , movingAverage{}
+            , direction(direction)
+            , ma{}
         {
         }
 
@@ -101,8 +109,7 @@ namespace Udon
         /// @param power パワー (-250 ～ 250)
         void move(const int16_t power)
         {
-            movingAverage.update(constrain(power, -250, 250));
-            const int16_t p = movingAverage.getValue();
+            const int16_t p = ma(constrain(power, -250, 250)) * Udon::DirectionToSign(direction);
             digitalWrite(pinA, p >= 0 ? HIGH : LOW);
             digitalWrite(pinB, p <= 0 ? HIGH : LOW);
             analogWrite(pinP, abs(p));
@@ -117,7 +124,7 @@ namespace Udon
         /// @brief パワーをシリアル出力
         void show() const
         {
-            Serial.print(movingAverage.getValue());
+            Serial.print(ma.getValue());
             Serial.print('\t');
         }
     };

--- a/src/Udon/Types/Direction.hpp
+++ b/src/Udon/Types/Direction.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace Udon
+{
+
+    /// @brief 方向
+    /// @note 回転方向を表す
+    enum class Direction
+    {
+        Forward,
+        Backward,
+    };
+
+    inline int DirectionToSign(Direction direction)
+    {
+        switch (direction)
+        {
+        case Direction::Forward: return 1;
+        case Direction::Backward: return -1;
+        }
+    }
+
+}    // namespace Udon

--- a/test/ArduinoLint/src/Driver/RoboMasterMotor.cpp
+++ b/test/ArduinoLint/src/Driver/RoboMasterMotor.cpp
@@ -20,7 +20,7 @@ __attribute__((unused)) static void test()
 {
     DummyBus bus;
     {
-        Udon::RoboMasterC610 motor{ bus, 0x000, true };
+        Udon::RoboMasterC610 motor{ bus, 0x000, Udon::Direction::Forward };
         motor.setCurrent(0);
         motor.getAngle();
         motor.getVelocity();
@@ -29,7 +29,7 @@ __attribute__((unused)) static void test()
     }
 
     {
-        Udon::RoboMasterC620 motor{ bus, 0x000, true };
+        Udon::RoboMasterC620 motor{ bus, 0x000, Udon::Direction::Backward };
         motor.setCurrent(0);
         motor.getAngle();
         motor.getVelocity();


### PR DESCRIPTION
回転方向の指定をbool値で行っていたので、Udon::Direction列挙型を導入した。

```cpp
Udon::RoboMasterC620 motor{ bus, 1, true };
```

↓

```cpp
Udon::RoboMasterC620 motor{ bus, 1, Udon::Direction::Forward };
```