### PR TITLE
Introduce dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,9 @@
+#
+#    GitHub Actions の依存関係の自動更新設定
+#
+#    Copyright (c) 2025 udonrobo
+#
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Why

Dependabot を有効化しておくと、適当なタイミングで GitHub Actions なんかの依存パッケージの更新を確認して勝手にアップデートの PR を生やしてくれます。 cf.
https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
競合するサービスとしては Renovate もありますが、Dependabot は GitHub が提供しているサービスであり課金もされないのでとりあえず有効化しても良いんじゃないでしょうか。

## What

Dependabot を導入し、週次で GitHub Actions のコマンド（`actions/checkout@v4` とか）の更新を確認してアップデートの PR を生やす設定を有効化します。
設定画面から手動でリポジトリ設定を変更する必要はなく、この PR をマージして `.github/dependabot.yml` を追加するだけで Dependabot は有効になります。cf.  https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#dependabot-version-updates-%E3%81%AE%E3%82%A2%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E6%9C%89%E5%8A%B9%E5%8C%96%E3%81%99%E3%82%8B

本 PR では GitHub Actions だけ更新を確認していますが、C++ ライブラリ側で依存ライブラリ等あればそちらも更新を確認するよう Dependabot を設定しても良いかもしれないです。